### PR TITLE
esbuild transpile to lower version.

### DIFF
--- a/build.js
+++ b/build.js
@@ -76,7 +76,7 @@ let version_short = (
 
 {
   let { stdout, stderr } = await exec(
-    `esbuild --format=esm --bundle ./src/client/pw-app.js --charset=utf8 --define:window.PRODUCTION=true --define:window.LANGUAGE=\\"${
+    `esbuild --target=es2020,chrome58,firefox57,safari11 --format=esm --bundle ./src/client/pw-app.js --charset=utf8 --define:window.PRODUCTION=true --define:window.LANGUAGE=\\"${
       process.env.LANGUAGE ?? "de"
     }\\" --define:window.VERSION_FULL=\\"${version_full}\\" --define:window.VERSION_SHORT=\\"${version_short}\\" --entry-names=[dir]/[name] --sourcemap  --analyze --outdir=dist --tree-shaking=true`
   );


### PR DESCRIPTION
I assume spread syntax is the culprit as the syntax crash also was at .